### PR TITLE
Improve typings in UI components and API service

### DIFF
--- a/src/components/Chat/ChatBot.tsx
+++ b/src/components/Chat/ChatBot.tsx
@@ -82,8 +82,12 @@ const ChatBot = () => {
     
     try {
       // Tentar processar via n8n primeiro
-      const context = lowerMessage.includes('agendar') ? 'appointment' : 
-                    lowerMessage.includes('emergência') ? 'emergency' : 'general';
+      const context: 'appointment' | 'emergency' | 'general' =
+        lowerMessage.includes('agendar')
+          ? 'appointment'
+          : lowerMessage.includes('emergência')
+            ? 'emergency'
+            : 'general';
       
       const response = await sendMessage(userMessage, context);
       
@@ -93,7 +97,7 @@ const ChatBot = () => {
           text: response.reply,
           sender: 'bot',
           timestamp: new Date(),
-          type: context as any
+          type: context
         };
       }
     } catch (error) {

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,9 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
-
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">

--- a/src/components/ui/confirmation-modal.tsx
+++ b/src/components/ui/confirmation-modal.tsx
@@ -13,6 +13,13 @@ import {
 import { animations } from '@/lib/animations';
 import { Calendar, X, User, AlertCircle } from 'lucide-react';
 
+export interface AppointmentDetails {
+  date: string;
+  time: string;
+  clinic: string;
+  service: string;
+}
+
 interface ConfirmationModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -20,7 +27,7 @@ interface ConfirmationModalProps {
   type: 'appointment' | 'cancel' | 'personal-data' | 'emergency';
   title?: string;
   description?: string;
-  data?: any;
+  data?: AppointmentDetails;
 }
 
 export const ConfirmationModal: React.FC<ConfirmationModalProps> = ({

--- a/src/components/ui/filters.tsx
+++ b/src/components/ui/filters.tsx
@@ -58,9 +58,12 @@ export const Filters: React.FC<FiltersProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const updateFilter = (key: keyof FilterState, value: any) => {
+  const updateFilter = <K extends keyof FilterState>(
+    key: K,
+    value: FilterState[K]
+  ) => {
     // Convert "all" back to empty string for filtering logic
-    const actualValue = value === "all" ? "" : value;
+    const actualValue = (value === "all" ? "" : value) as FilterState[K];
     onFiltersChange({ ...filters, [key]: actualValue });
   };
 

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,10 +2,10 @@ import * as React from "react"
 
 import { cn } from "../../lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
-
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(
   ({ className, ...props }, ref) => {
     return (
       <textarea

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,15 +1,17 @@
 
 // Mock API service para simular integrações futuras
-export interface ChatMessage {
+export interface ChatAction<T = unknown> {
+  type: 'schedule' | 'call' | 'location';
+  label: string;
+  data?: T;
+}
+
+export interface ChatMessage<T = unknown> {
   id: string;
   type: 'user' | 'bot';
   content: string;
   timestamp: Date;
-  actions?: Array<{
-    type: 'schedule' | 'call' | 'location';
-    label: string;
-    data?: any;
-  }>;
+  actions?: Array<ChatAction<T>>;
 }
 
 export interface AppointmentData {
@@ -22,6 +24,16 @@ export interface AppointmentData {
     phone: string;
     email: string;
   };
+}
+
+export interface UserAppointment {
+  id: string;
+  service: string;
+  clinic: string;
+  doctor: string;
+  date: string;
+  time: string;
+  status: 'confirmed' | 'pending' | 'cancelled';
 }
 
 export interface UserProfile {
@@ -206,7 +218,7 @@ export const apiService = {
       return baseSlots.filter(() => Math.random() > 0.3); // Remove alguns aleatoriamente
     },
 
-    getUserAppointments: async (userId: string): Promise<any[]> => {
+    getUserAppointments: async (userId: string): Promise<UserAppointment[]> => {
       await delay(600);
       return [
         {


### PR DESCRIPTION
## Summary
- replace various `any` usages with typed interfaces and generics
- remove empty `CommandDialogProps` interface
- inline textarea props type
- improve context typing in `ChatBot`
- add user appointment type and use it

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6848498f4f0883209d05bededdd084a0