### PR TITLE
Remove unused env vars from homepage

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -152,13 +152,6 @@ const Index = () => {
     navigate('/emergency');
   };
 
-  const whatsappKey = import.meta.env.VITE_N8N_WEBHOOK_URL;
-
-  const apiUrl = import.meta.env.API_URL;
-  if (!apiUrl) {
-    console.error('API_URL is not defined in environment variables');
-  }
-
   if (isLoading) {
     return (
       <div className="p-6 space-y-6">


### PR DESCRIPTION
## Summary
- remove unused `whatsappKey` and `apiUrl` variables

## Testing
- `npm run lint` *(fails: Unexpected any, react-refresh/only-export-components, etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684849977f5083209d27ec70cc664110