### PR TITLE
Switch from Jest to Vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build:staging": "vite build --mode staging",
     "preview": "vite preview",
     "type-check": "tsc --noEmit",
-    "test": "jest",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
     "lint": "eslint .",
     "lighthouse": "lighthouse https://sorriso-inteligente-app.lovable.app --output html"
   },
@@ -79,7 +80,6 @@
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",
     "lovable-tagger": "^1.1.7",
-    "jest": "^28.0.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.11",
     "typescript": "^5.8.3",

--- a/tests/sample.test.js
+++ b/tests/sample.test.js
@@ -1,3 +1,5 @@
+import { describe, it, expect } from "vitest";
+
 describe("Sample Test", () => {
   it("should pass", () => {
     expect(true).toBe(true);


### PR DESCRIPTION
## Summary
- migrate test runner to vitest
- remove unused jest dependency
- update sample test for vitest globals

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848499ac3508320a919c46e300c162f