### PR TITLE
Fix accessibility warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ cp .env.example .env.local
 npm run dev
 ```
 
+### Executando Testes
+Antes de rodar os testes automatizados, instale as dependências do projeto:
+
+```bash
+npm ci
+```
+
+Em seguida execute:
+
+```bash
+npm test --silent
+```
+
 ### Available NPM Scripts
 
 Adicione os seguintes scripts ao seu `package.json` para suporte completo aos ambientes:

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -69,6 +69,11 @@ bun run preview
 
 ### Testes
 ```bash
+# Certifique-se de instalar as dependências antes de rodar os testes
+bun install
+# ou
+npm ci
+
 # Executar testes
 bun run test
 

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
   </head>
 
   <body>
-    <div id="root"></div>
+    <div id="root" role="main"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/Dashboard/HomePage.tsx
+++ b/src/components/Dashboard/HomePage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { PWADashboard, PWAQuickInstall } from '@/components/ui/pwa-dashboard';
 import { toastSuccess, toastInfo, toastAppointment, toastCall } from '@/components/ui/custom-toast';
 import { useAppointmentScheduler } from '@/hooks/useAppointmentScheduler';
@@ -138,7 +138,7 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
           <CardContent className="p-4 text-center">
             <MessageCircle className="h-8 w-8 mx-auto mb-2 text-primary" />
             <p className="font-medium">Chat IA</p>
-            <p className="text-xs text-gray-500">Tire suas dúvidas</p>
+            <p className="text-xs text-gray-700">Tire suas dúvidas</p>
           </CardContent>
         </Card>
 
@@ -149,7 +149,7 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
           <CardContent className="p-4 text-center">
             <MapPin className="h-8 w-8 mx-auto mb-2 text-primary" />
             <p className="font-medium">Unidades</p>
-            <p className="text-xs text-gray-500">5 cidades</p>
+            <p className="text-xs text-gray-700">5 cidades</p>
           </CardContent>
         </Card>
 
@@ -160,7 +160,7 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
           <CardContent className="p-4 text-center">
             <Calendar className="h-8 w-8 mx-auto mb-2 text-primary" />
             <p className="font-medium">Agendar</p>
-            <p className="text-xs text-gray-500">Nova consulta</p>
+            <p className="text-xs text-gray-700">Nova consulta</p>
           </CardContent>
         </Card>
 
@@ -171,7 +171,7 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
           <CardContent className="p-4 text-center">
             <Phone className="h-8 w-8 mx-auto mb-2 text-primary" />
             <p className="font-medium">Urgência</p>
-            <p className="text-xs text-gray-500">Atendimento 24h</p>
+            <p className="text-xs text-gray-700">Atendimento 24h</p>
           </CardContent>
         </Card>
       </div>
@@ -179,20 +179,20 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
       {/* Nossas Unidades - ENDEREÇOS CORRIGIDOS */}
       <Card className={animations.slideInLeft}>
         <CardHeader>
-          <CardTitle className="flex items-center justify-between">
+          <h2 className="flex items-center justify-between text-2xl font-semibold leading-none tracking-tight">
             <div className="flex items-center">
               <MapPin className="h-5 w-5 mr-2" />
               Nossas Unidades
             </div>
-            <Button 
-              variant="ghost" 
+            <Button
+              variant="ghost"
               size="sm"
               onClick={handleViewUnits}
               className={animations.buttonHover}
             >
               Ver todas
             </Button>
-          </CardTitle>
+          </h2>
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -201,7 +201,7 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
                 <div>
                   <p className="font-medium">Campo Belo - MG</p>
                   <p className="text-sm text-gray-600">Av. Afonso Pena, 151</p>
-                  <p className="text-xs text-gray-500">(35) 99869-5479</p>
+                  <p className="text-xs text-gray-700">(35) 99869-5479</p>
                 </div>
                 <Button 
                   size="sm" 
@@ -219,7 +219,7 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
                 <div>
                   <p className="font-medium">Formiga - MG</p>
                   <p className="text-sm text-gray-600">R. Barão de Piumhy, 198</p>
-                  <p className="text-xs text-gray-500">(35) 9969-5479</p>
+                  <p className="text-xs text-gray-700">(35) 9969-5479</p>
                 </div>
                 <Button 
                   size="sm" 
@@ -238,10 +238,10 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
       {/* Próximas Consultas */}
       <Card className={animations.slideInRight}>
         <CardHeader>
-          <CardTitle className="flex items-center">
+          <h2 className="flex items-center text-2xl font-semibold leading-none tracking-tight">
             <Clock className="h-5 w-5 mr-2" />
             Próximas Consultas
-          </CardTitle>
+          </h2>
         </CardHeader>
         <CardContent>
           <div className="space-y-3">
@@ -249,7 +249,7 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
               <div>
                 <p className="font-medium">Limpeza Dental</p>
                 <p className="text-sm text-gray-600">Campo Belo - Dr. Silva</p>
-                <p className="text-xs text-gray-500">15/06/2024 às 14:00</p>
+                <p className="text-xs text-gray-700">15/06/2024 às 14:00</p>
               </div>
               <Button 
                 size="sm" 
@@ -277,7 +277,7 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
       {/* Serviços em Destaque */}
       <Card className={animations.fadeIn}>
         <CardHeader>
-          <CardTitle>Nossos Serviços</CardTitle>
+          <h2 className="text-2xl font-semibold leading-none tracking-tight">Nossos Serviços</h2>
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
@@ -313,10 +313,10 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
       {/* Avaliações */}
       <Card className={animations.slideInBottom}>
         <CardHeader>
-          <CardTitle className="flex items-center">
+          <h2 className="flex items-center text-2xl font-semibold leading-none tracking-tight">
             <Star className="h-5 w-5 mr-2 text-yellow-500" />
             Avaliações de Pacientes
-          </CardTitle>
+          </h2>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
@@ -353,7 +353,7 @@ export const HomePage: React.FC<HomePageProps> = ({ onNavigate }) => {
           <div className="flex items-center justify-between">
             <div>
               <h3 className="font-semibold text-red-800">Urgência Dental 24h</h3>
-              <p className="text-sm text-red-600">Atendimento imediato para emergências</p>
+              <p className="text-sm text-red-700">Atendimento imediato para emergências</p>
             </div>
             <Button 
               className={`bg-red-600 hover:bg-red-700 ${animations.buttonHover}`}

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -98,20 +98,22 @@ export const Header: React.FC = () => {
     <header className="bg-white shadow-sm border-b px-4 py-3 flex items-center justify-between">
       <div className="flex items-center space-x-3 flex-1">
         {showBackButton && (
-          <Button 
-            variant="ghost" 
-            size="icon" 
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={handleBack}
             className="mr-2"
+            aria-label="Voltar"
           >
             <ArrowLeft className="h-5 w-5" />
           </Button>
         )}
-        <Button 
-          variant="ghost" 
-          size="icon" 
+        <Button
+          variant="ghost"
+          size="icon"
           className="md:hidden"
           onClick={handleMenuClick}
+          aria-label="Abrir menu"
         >
           <Menu className="h-5 w-5" />
         </Button>
@@ -141,17 +143,18 @@ export const Header: React.FC = () => {
       
       <div className="flex items-center space-x-2">
         {/* Botão de Pesquisa */}
-        <Button 
-          variant="ghost" 
+        <Button
+          variant="ghost"
           size="icon"
           onClick={toggleSearch}
           className="hidden sm:flex"
+          aria-label="Pesquisar"
         >
           <Search className="h-5 w-5" />
         </Button>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" className="relative">
+            <Button variant="ghost" size="icon" className="relative" aria-label="Notificações">
               <Bell className="h-5 w-5" />
               {notificationCount > 0 && (
                 <Badge 
@@ -195,7 +198,7 @@ export const Header: React.FC = () => {
         
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon">
+            <Button variant="ghost" size="icon" aria-label="Menu do usuário">
               <User className="h-5 w-5" />
             </Button>
           </DropdownMenuTrigger>
@@ -236,7 +239,7 @@ export const Header: React.FC = () => {
                 </div>
                 <span className="font-semibold text-lg text-primary">Sorriso Inteligente</span>
               </div>
-              <Button variant="ghost" size="icon" onClick={() => setShowMobileMenu(false)}>
+              <Button variant="ghost" size="icon" onClick={() => setShowMobileMenu(false)} aria-label="Fechar menu">
                 <ArrowLeft className="h-5 w-5" />
               </Button>
             </div>

--- a/src/pages/EmergencyPage.tsx
+++ b/src/pages/EmergencyPage.tsx
@@ -18,7 +18,7 @@ const EmergencyPage = () => {
   return (
     <div className="p-6 space-y-6">
       <div className="text-center mb-6">
-        <h1 className="text-2xl font-bold text-red-600 flex items-center justify-center gap-2">
+        <h1 className="text-2xl font-bold text-red-700 flex items-center justify-center gap-2">
           <AlertTriangle className="h-6 w-6" />
           Emergência Odontológica
         </h1>
@@ -32,7 +32,7 @@ const EmergencyPage = () => {
           <CardTitle className="text-red-700">Situação de Emergência?</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <p className="text-red-600 font-medium">
+          <p className="text-red-700 font-medium">
             Para situações de extrema urgência, ligue imediatamente:
           </p>
           <Button 


### PR DESCRIPTION
## Summary
- add main landmark role to root element
- improve accessible labels for header buttons
- adjust text colors for better contrast
- restructure card titles as h2 headings
- document how to run tests

## Testing
- `npm test --silent`
- `npm run lint` *(fails: 35 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848d0f217808320813f84784cd5726b