### PR TITLE
Add basic Supabase auth context and loyalty migration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,9 @@ import ChatPage from '@/pages/ChatPage';
 import EmergencyPage from '@/pages/EmergencyPage';
 import ProfilePage from '@/pages/ProfilePage';
 import { PWASettingsPage } from '@/pages/PWASettingsPage';
+import Login from '@/pages/auth/Login';
+import SignUp from '@/pages/auth/SignUp';
+import { RequireAuth } from './contexts/RequireAuth';
 import NotFound from '@/pages/NotFound';
 import Index from '@/pages/Index';
 import { Toaster } from '@/components/ui/toaster';
@@ -30,18 +33,29 @@ const App = () => {
       <div className="App">
         <MainLayout currentPage={currentPage} onPageChange={handlePageChange}>
           <Routes>
-            <Route path="/" element={<HomePage onNavigate={handleNavigate} />} />
-            <Route path="/home" element={<HomePage onNavigate={handleNavigate} />} />
-            <Route path="/index" element={<Index />} />
-            <Route path="/locations" element={<LocationsPage />} />
-            <Route path="/clinics" element={<LocationsPage />} />
-            <Route path="/appointments" element={<AppointmentScheduler />} />
-            <Route path="/schedule" element={<AppointmentScheduler />} />
-            <Route path="/chat" element={<ChatPage />} />
-            <Route path="/emergency" element={<EmergencyPage />} />
-            <Route path="/profile" element={<ProfilePage />} />
-            <Route path="/pwa-settings" element={<PWASettingsPage onNavigate={handleNavigate} />} />
-            <Route path="*" element={<NotFound />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/sign-up" element={<SignUp />} />
+            <Route
+              path="/*"
+              element={
+                <RequireAuth>
+                  <Routes>
+                    <Route path="/" element={<HomePage onNavigate={handleNavigate} />} />
+                    <Route path="/home" element={<HomePage onNavigate={handleNavigate} />} />
+                    <Route path="/index" element={<Index />} />
+                    <Route path="/locations" element={<LocationsPage />} />
+                    <Route path="/clinics" element={<LocationsPage />} />
+                    <Route path="/appointments" element={<AppointmentScheduler />} />
+                    <Route path="/schedule" element={<AppointmentScheduler />} />
+                    <Route path="/chat" element={<ChatPage />} />
+                    <Route path="/emergency" element={<EmergencyPage />} />
+                    <Route path="/profile" element={<ProfilePage />} />
+                    <Route path="/pwa-settings" element={<PWASettingsPage onNavigate={handleNavigate} />} />
+                    <Route path="*" element={<NotFound />} />
+                  </Routes>
+                </RequireAuth>
+              }
+            />
           </Routes>
         </MainLayout>
         <Toaster />

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useEffect, useState, type PropsWithChildren } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { supabase } from '@/lib/supabase'
+
+interface AuthContextValue {
+  user: User | null
+}
+
+export const AuthContext = createContext<AuthContextValue>({ user: null })
+
+export const AuthProvider = ({ children }: PropsWithChildren) => {
+  const [user, setUser] = useState<User | null>(null)
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => setUser(data.user ?? null))
+    const { data: listener } = supabase.auth.onAuthStateChange((_e, session) => {
+      setUser(session?.user ?? null)
+    })
+    return () => {
+      listener.subscription.unsubscribe()
+    }
+  }, [])
+
+  return <AuthContext.Provider value={{ user }}>{children}</AuthContext.Provider>
+}

--- a/src/contexts/RequireAuth.tsx
+++ b/src/contexts/RequireAuth.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { Navigate } from 'react-router-dom'
+import { AuthContext } from './AuthProvider'
+
+export const RequireAuth: React.FC<{ children: React.ReactElement }> = ({ children }) => {
+  const { user } = React.useContext(AuthContext)
+  if (!user) return <Navigate to="/login" replace />
+  return children
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,12 @@
+import { createClient } from '@supabase/supabase-js'
+
+export const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_ANON_KEY,
+  {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true
+    }
+  }
+)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,14 @@
 
 import { createRoot } from 'react-dom/client'
 import App from './App'
+import { AuthProvider } from './contexts/AuthProvider'
 import './index.css'
 
 const container = document.getElementById('root')!
 const root = createRoot(container)
 
-root.render(<App />)
+root.render(
+  <AuthProvider>
+    <App />
+  </AuthProvider>
+)

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { supabase } from '@/lib/supabase'
+
+export default function Login() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const navigate = useNavigate()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (error) setError(error.message)
+    else navigate('/dashboard')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-sm mx-auto mt-10 flex flex-col gap-4">
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <input className="border p-2" type="email" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+      <input className="border p-2" type="password" placeholder="Senha" value={password} onChange={e => setPassword(e.target.value)} />
+      <button type="submit" className="bg-primary text-white p-2 rounded">Entrar</button>
+    </form>
+  )
+}

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { supabase } from '@/lib/supabase'
+
+export default function SignUp() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const navigate = useNavigate()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { error } = await supabase.auth.signUp({ email, password })
+    if (error) setError(error.message)
+    else navigate('/dashboard')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-sm mx-auto mt-10 flex flex-col gap-4">
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <input className="border p-2" type="email" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+      <input className="border p-2" type="password" placeholder="Senha" value={password} onChange={e => setPassword(e.target.value)} />
+      <button type="submit" className="bg-primary text-white p-2 rounded">Criar conta</button>
+    </form>
+  )
+}

--- a/supabase/migrations/20250611T1205_core.sql
+++ b/supabase/migrations/20250611T1205_core.sql
@@ -1,0 +1,56 @@
+create table clinics (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  address text
+);
+
+create table services (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  points integer default 0
+);
+
+create type appointment_status as enum ('scheduled','completed','cancelled','no_show');
+
+create table appointments (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users,
+  clinic_id uuid references clinics,
+  service_id uuid references services,
+  scheduled_at timestamptz,
+  status appointment_status default 'scheduled',
+  created_at timestamptz default now()
+);
+
+create table loyalty_points (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users,
+  appointment_id uuid references appointments,
+  points integer not null,
+  created_at timestamptz default now()
+);
+
+alter table appointments enable row level security;
+create policy "User appointments"
+  on appointments for all
+  using (auth.uid() = user_id);
+
+alter table loyalty_points enable row level security;
+create policy "User points"
+  on loyalty_points for all
+  using (auth.uid() = user_id);
+
+create or replace function handle_points()
+returns trigger as $$
+begin
+  if new.status = 'completed' then
+    insert into loyalty_points(user_id, appointment_id, points)
+    select new.user_id, new.id, s.points from services s where s.id = new.service_id;
+  end if;
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_appointment_points
+after update of status on appointments
+for each row execute procedure handle_points();


### PR DESCRIPTION
## Summary
- integrate Supabase client with new `AuthProvider` context and `RequireAuth`
- add login and sign‑up pages
- add simple routing wrapper requiring auth
- create initial Supabase migration with clinics, appointments and loyalty points

## Testing
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848f351a7748320977248ba1a2f82d8