### PR TITLE
Fix Supabase service typings

### DIFF
--- a/src/services/supabase/appointments.ts
+++ b/src/services/supabase/appointments.ts
@@ -1,11 +1,19 @@
 // Supabase service for managing appointments
 import { supabase } from '../../integrations/supabase/client'
-import type { 
-  Appointment, 
-  AppointmentInsert, 
+import type {
+  Appointment,
+  AppointmentInsert,
   AppointmentUpdate,
-  Database 
+  AppointmentStatus,
+  Database
 } from '../../integrations/supabase/types'
+
+interface OpeningHours {
+  [day: string]: {
+    open: string
+    close: string
+  }
+}
 
 export class AppointmentService {
   /**
@@ -35,9 +43,9 @@ export class AppointmentService {
    * Get user appointments
    */
   static async getUserAppointments(
-    userId: string, 
+    userId: string,
     options?: {
-      status?: string[]
+      status?: AppointmentStatus[]
       limit?: number
       upcoming?: boolean
     }
@@ -53,7 +61,7 @@ export class AppointmentService {
       .eq('patient_id', userId)
 
     if (options?.status) {
-      query = query.in('status', options.status as any)
+      query = query.in('status', options.status)
     }
 
     if (options?.upcoming) {
@@ -200,7 +208,7 @@ export class AppointmentService {
 
     // Generate available slots based on working hours and existing appointments
     const dayOfWeek = new Date(date).toLocaleDateString('en-US', { weekday: 'long' }).toLowerCase()
-    const workingHours = clinic.opening_hours as any
+    const workingHours = clinic.opening_hours as unknown as OpeningHours | null
     
     if (!workingHours || !workingHours[dayOfWeek]) {
       return [] // Clinic closed on this day


### PR DESCRIPTION
## Summary
- fix lint failures by removing `any` from supabase services
- use `AppointmentStatus` for filtering appointments
- define `OpeningHours` and `ReviewWithRelations` helper interfaces

## Testing
- `pnpm exec eslint src/services/supabase/appointments.ts src/services/supabase/clinics.ts`
- `pnpm type-check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6848fef089f08320a382d1cbbc8af950